### PR TITLE
Fix url permission

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -14,7 +14,7 @@
     ]
   },
   "permissions": [
-    "tabs", "https://*/*", "clipboardRead"
+    "tabs", "https://trello.com/*", "clipboardRead"
   ],
   "browser_action": {
     "default_title": "Print this page",


### PR DESCRIPTION
Fix url permission from `https://*` to `http://trello.com/*` 😄 